### PR TITLE
fix: replace loader ID with string literal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export const pluginTypedCSSModules = (): RsbuildPlugin => ({
             }
 
             rule
-              .use(CHAIN_ID.USE.CSS_MODULES_TS)
+              .use('css-modules-typescript')
               .loader(path.resolve(__dirname, './loader.cjs'))
               .options({
                 modules: cssLoaderOptions.modules,


### PR DESCRIPTION
Replace loader ID with string literal to reduce coupling with @rsbuild/core.