### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
   "version": "1.2.4",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-typed-css-modules#readme",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-typed-css-modules",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-typed-css-modules/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the repository README
- add `bugs.url` metadata pointing to the GitHub issue tracker
- keep runtime code, dependencies, exports, package contents, and version unchanged

## Validation
- `node -e "const p=require('./package.json'); if(p.name!=='@rsbuild/plugin-typed-css-modules') throw new Error('bad name'); if(p.homepage!=='https://github.com/rstackjs/rsbuild-plugin-typed-css-modules#readme') throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/rstackjs/rsbuild-plugin-typed-css-modules/issues') throw new Error('bad bugs'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2));"`
- `npm view @rsbuild/plugin-typed-css-modules@1.2.4 name version repository homepage bugs license --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: `npm pack --dry-run --ignore-scripts --json .` still ran the repository's existing `prepare` hook and configured simple-git-hooks locally, but it did not create any tracked file changes.